### PR TITLE
Fixed e-mail reading order, compatibility to exchange 2010 and recursively add attachments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -i https://pypi.org/simple
 asn1crypto==0.24.0
+bs4==0.0.1
 cached-property==1.5.1
 certifi==2018.8.24
 cffi==1.11.5

--- a/workflows/Ews2Case.py
+++ b/workflows/Ews2Case.py
@@ -11,6 +11,7 @@ from common.common import getConf
 from objects.EwsConnector import EwsConnector
 from objects.TheHiveConnector import TheHiveConnector
 from objects.TempAttachment import TempAttachment
+from bs4 import BeautifulSoup
 
 def connectEws():
     logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ def connectEws():
 
         theHiveConnector = TheHiveConnector(cfg)
 
-        for msg in unread:
+        for msg in reversed(unread):
             #type(msg)
             #<class 'exchangelib.folders.Message'>
             conversationId = msg.conversation_id.id
@@ -148,14 +149,16 @@ def getEmailBody(email):
 
     body = email.text_body
 
-    #alternate way to get the body
-    #soup = BeautifulSoup(email.body, 'html.parser')
-    #try:
-    #    #html email
-    #    body = soup.body.text
-    #except AttributeError:
-    #    #non html email
-    #    body = soup.text
+    #exchange 2010 doesn't have attribute text_body, need to treat body as html
+    if body is None:
+        #alternate way to get the body
+        soup = BeautifulSoup(msg.body, 'html.parser')
+        try:
+            #html email
+            body = soup.body.text
+        except AttributeError:
+            #non html email
+            body = soup.text
 
     return ('```\n' + replyToInfo + body + '\n```')
 

--- a/workflows/objects/TheHiveConnector.py
+++ b/workflows/objects/TheHiveConnector.py
@@ -166,6 +166,9 @@ class TheHiveConnector:
         if response.status_code == 201:
             esObservableId = response.json()['id']
             return esObservableId
+        # ignores the attachment if is already in the case
+        elif response.status_code == 400 and response.json().get('message', '') == 'Artifact already exists':
+            return None
         else:
             self.logger.error('File observable upload failed')
             raise ValueError(json.dumps(response.json(), indent=4, sort_keys=True))


### PR DESCRIPTION
Reads e-mails from the oldest to newest
Using Beautifulsoap to read exchange 2010 and older e-mails (they don't have text_body attribute)
Includes attachments now recursively, not only first level  …
Ignores if the artifact is already in the case, instead of getting an error