### PR TITLE
Fix: Mail attachments not being read when there are inline attachments. Need to upgrade exchangelib version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==7.0
 cryptography==2.3.1
 defusedxml==0.5.0
 dnspython==1.15.0
-exchangelib==1.12.0
+exchangelib==1.12.5
 flask==1.0.2
 future==0.16.0
 idna==2.7


### PR DESCRIPTION
Exchangelib has an important fix update: When reading an email with an inline image(s), emails that have been attached to the original email do not appear in the attachments attribute of the Message object.
Fix #36 