### PR TITLE
Update TheHiveConnector.py

### DIFF
--- a/workflows/objects/TheHiveConnector.py
+++ b/workflows/objects/TheHiveConnector.py
@@ -164,7 +164,7 @@ class TheHiveConnector:
             esCaseId, file_observable)
 
         if response.status_code == 201:
-            esObservableId = response.json()['id']
+            esObservableId = (response.json()[0])['id']
             return esObservableId
         else:
             self.logger.error('File observable upload failed')


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/snort/Synapse/workflows/Ews2Case.py", line 103, in connectEws
    comment)
  File "/home/snort/Synapse/workflows/objects/TheHiveConnector.py", line 167, in addFileObservable
    esObservableId = response.json()['id']
TypeError: list indices must be integers or slices, not str

response.json()['id'] return a list not a dict, we accessed the list to access the dictionary